### PR TITLE
Overridable server timeout in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ COPY ./spielerplus_calendar ./spielerplus_calendar
 
 # Run Application
 EXPOSE 5000
-CMD [ "poetry", "run", "gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "300", "spielerplus_calendar.server:app" ]
+CMD [ "poetry", "run", "gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "600", "spielerplus_calendar.server:app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,5 @@ COPY ./spielerplus_calendar ./spielerplus_calendar
 
 # Run Application
 EXPOSE 5000
-CMD [ "poetry", "run", "gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "600", "spielerplus_calendar.server:app" ]
+ENV SERVER_TIMEOUT=300
+CMD poetry run gunicorn --bind 0.0.0.0:5000 --workers 4 --timeout $SERVER_TIMEOUT spielerplus_calendar.server:app

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ Generates ICS output for custom postprocessing:<br/>
 Starts a production ready server in a docker container:<br/>
 `docker run -p 5000:5000 -v $(pwd)/config.json:/app/config.json:ro djbrown/spielerplus-calendar`
 The server will be reachable under port `5000` on all public ip addresses of your machine.
+You may optionally change the default server timeout (300s) e.g: `-e SERVER_TIMEOUT=600`.


### PR DESCRIPTION
Hi @djbrown 
in my usecase, it takes ~6min to generate the response for the personal API on my RaspberryPi 3.
Thereby I increased the timeout locally, not sure if you want to adapt or make it configurable?